### PR TITLE
[#11] 공공데이터 API 사용하여 월별 아파트 가격 정보 파싱 

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -21,13 +21,18 @@ repositories {
 dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-data-jdbc'
 	implementation 'org.springframework.boot:spring-boot-starter-web'
-	//implementation 'org.springframework.boot:spring-boot-starter-security'
 	implementation 'org.mindrot:jbcrypt:0.3m'
 	implementation 'org.mybatis.spring.boot:mybatis-spring-boot-starter:2.2.0'
 	implementation 'org.springframework.session:spring-session-core'
 	implementation 'org.springframework.session:spring-session-jdbc:2.5.3'
 	implementation 'org.apache.poi:poi:5.0.0'
 	implementation 'org.apache.poi:poi-ooxml:5.0.0'
+
+	// xml to object
+	implementation('javax.xml.bind:jaxb-api:2.3.0')
+	implementation('javax.activation:activation:1.1')
+	implementation('org.glassfish.jaxb:jaxb-runtime:2.3.0')
+
 	compileOnly 'org.projectlombok:lombok'
 	annotationProcessor 'org.projectlombok:lombok'
 	developmentOnly 'org.springframework.boot:spring-boot-devtools'

--- a/src/main/java/kancho/realestate/comparingprices/domain/dto/request/RequestApartmentDetailDto.java
+++ b/src/main/java/kancho/realestate/comparingprices/domain/dto/request/RequestApartmentDetailDto.java
@@ -1,0 +1,49 @@
+package kancho.realestate.comparingprices.domain.dto.request;
+
+import java.time.LocalDateTime;
+
+import kancho.realestate.comparingprices.domain.model.Gu;
+import kancho.realestate.comparingprices.exception.InvalidDealYearAndMonthException;
+import kancho.realestate.comparingprices.exception.InvalidRegionalCodeException;
+import lombok.Getter;
+
+@Getter
+public class RequestApartmentDetailDto {
+	private String regionalCode;
+	private int dealYear;
+	private int dealMonth;
+
+	public RequestApartmentDetailDto(String regionalCode, int dealYear, int dealMonth) {
+		if (!isCorrectRegionalCode(regionalCode)){
+			throw new InvalidRegionalCodeException(regionalCode);
+		}
+
+		if (!isCorrectDealYearAndMonth(dealYear, dealMonth)) {
+			throw new InvalidDealYearAndMonthException(dealYear, dealMonth);
+		}
+
+		this.regionalCode = regionalCode;
+		this.dealYear = dealYear;
+		this.dealMonth = dealMonth;
+	}
+
+	private boolean isCorrectRegionalCode(String regionalCode) {
+		return Gu.isCorrectRegionalCode(regionalCode);
+	}
+
+	private boolean isCorrectDealYearAndMonth(int dealYear, int dealMonth) {
+		int nowYear = LocalDateTime.now().getYear();
+		int nowMonth = LocalDateTime.now().getMonthValue();
+
+		if (dealYear < nowYear) {
+			if (dealMonth >= 1 && dealMonth <= 12) {
+				return true;
+			}
+		} else if (dealYear == nowYear) {
+			if (dealMonth >= 1 && dealMonth <= nowMonth) {
+				return true;
+			}
+		}
+		return false;
+	}
+}

--- a/src/main/java/kancho/realestate/comparingprices/domain/model/ApartmentDetail.java
+++ b/src/main/java/kancho/realestate/comparingprices/domain/model/ApartmentDetail.java
@@ -1,0 +1,50 @@
+package kancho.realestate.comparingprices.domain.model;
+
+import java.time.LocalDateTime;
+
+import javax.xml.bind.annotation.XmlAccessType;
+import javax.xml.bind.annotation.XmlAccessorType;
+import javax.xml.bind.annotation.XmlElement;
+
+import lombok.Getter;
+import lombok.Setter;
+import lombok.ToString;
+
+@ToString
+@Getter
+@Setter
+@XmlAccessorType(XmlAccessType.FIELD)
+public class ApartmentDetail {
+	// 아파트 정보
+	@XmlElement(name = "지역코드")
+	private String regionalCode;
+	@XmlElement(name = "법정동")
+	private String dong;
+	@XmlElement(name = "지번")
+	private String jibun;
+	@XmlElement(name = "법정동본번코드")
+	private String bonbun;
+	@XmlElement(name = "법정동부번코드")
+	private String bubun;
+	@XmlElement(name = "아파트")
+	private String apartmentName;
+	@XmlElement(name = "건축년도")
+	private int buildYear;
+	@XmlElement(name = "도로명")
+	private String roadAddress;
+
+	// 아파트 가격 정보
+	private long apartmentId;
+	@XmlElement(name = "전용면적")
+	private float areaForExclusiveUse;
+	@XmlElement(name = "년")
+	private int dealYear;
+	@XmlElement(name = "월")
+	private int dealMonth;
+	@XmlElement(name = "일")
+	private int dealDay;
+	@XmlElement(name = "거래금액")
+	private String dealAmount;
+	@XmlElement(name = "층")
+	private int floor;
+}

--- a/src/main/java/kancho/realestate/comparingprices/domain/model/ApartmentDetails.java
+++ b/src/main/java/kancho/realestate/comparingprices/domain/model/ApartmentDetails.java
@@ -1,0 +1,22 @@
+package kancho.realestate.comparingprices.domain.model;
+
+import java.util.List;
+
+import javax.xml.bind.annotation.XmlAccessType;
+import javax.xml.bind.annotation.XmlAccessorType;
+import javax.xml.bind.annotation.XmlElement;
+import javax.xml.bind.annotation.XmlRootElement;
+
+import lombok.Getter;
+import lombok.Setter;
+import lombok.ToString;
+
+@ToString
+@Setter
+@Getter
+@XmlRootElement(name = "items")
+@XmlAccessorType(XmlAccessType.FIELD)
+public class ApartmentDetails {
+	@XmlElement(name = "item")
+	private List<ApartmentDetail> apartmentDetailList;
+}

--- a/src/main/java/kancho/realestate/comparingprices/domain/model/Gu.java
+++ b/src/main/java/kancho/realestate/comparingprices/domain/model/Gu.java
@@ -1,0 +1,30 @@
+package kancho.realestate.comparingprices.domain.model;
+
+public enum Gu {
+	강남구("11680"), 강동구("11740"), 강북구("11305"), 강서구("11500"),
+	관악구("11620"), 광진구("11215"), 구로구("11530"), 금천구("11545"),
+	노원구("11350"), 도봉구("11320"), 동대문구("11230"), 동작구("11590"),
+	마포구("11440"), 서대문구("11410"), 서초구("11650"), 성동구("11200"),
+	성북구("11290"), 송파구("11710"), 양천구("11470"), 영등포구("11560"),
+	용산구("11170"), 은평구("11380"), 종로구("11110"), 중구("11140"),
+	중랑구("11260");
+
+	private String regionalCode;
+
+	private Gu(String regionalCode) {
+		this.regionalCode = regionalCode;
+	}
+
+	public String getReginalCode() {
+		return regionalCode;
+	}
+
+	public static boolean isCorrectRegionalCode(String regionalCode) {
+		for (Gu gu : Gu.values()) {
+			if (gu.getReginalCode().equals(regionalCode)) {
+				return true;
+			}
+		}
+		return false;
+	}
+}

--- a/src/main/java/kancho/realestate/comparingprices/exception/InvalidApartmentXmlException.java
+++ b/src/main/java/kancho/realestate/comparingprices/exception/InvalidApartmentXmlException.java
@@ -1,0 +1,9 @@
+package kancho.realestate.comparingprices.exception;
+
+import org.springframework.data.relational.core.sql.In;
+
+public class InvalidApartmentXmlException extends RuntimeException{
+	public InvalidApartmentXmlException (String xmlString) {
+		super(xmlString + "은 올바르지 않은 xml 데이터입니다.");
+	}
+}

--- a/src/main/java/kancho/realestate/comparingprices/exception/InvalidDealYearAndMonthException.java
+++ b/src/main/java/kancho/realestate/comparingprices/exception/InvalidDealYearAndMonthException.java
@@ -1,0 +1,7 @@
+package kancho.realestate.comparingprices.exception;
+
+public class InvalidDealYearAndMonthException extends RuntimeException{
+	public InvalidDealYearAndMonthException(int dealYear, int dealMonth) {
+		super(dealYear + "년 " + dealMonth + "월은 올바른 날짜가 아닙니다.");
+	}
+}

--- a/src/main/java/kancho/realestate/comparingprices/exception/InvalidRegionalCodeException.java
+++ b/src/main/java/kancho/realestate/comparingprices/exception/InvalidRegionalCodeException.java
@@ -1,0 +1,7 @@
+package kancho.realestate.comparingprices.exception;
+
+public class InvalidRegionalCodeException extends RuntimeException{
+	public InvalidRegionalCodeException(String regionalCode) {
+		super(regionalCode + "는 존재하지 않는 지역번호 입니다.");
+	}
+}

--- a/src/main/java/kancho/realestate/utils/api/storeaprtment/ApartmentApiClient.java
+++ b/src/main/java/kancho/realestate/utils/api/storeaprtment/ApartmentApiClient.java
@@ -1,0 +1,77 @@
+package kancho.realestate.utils.api.storeaprtment;
+
+import static java.net.URLEncoder.*;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.io.UnsupportedEncodingException;
+import java.net.HttpURLConnection;
+import java.net.URL;
+import java.util.List;
+
+import javax.xml.bind.JAXBException;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+
+import kancho.realestate.comparingprices.domain.dto.request.RequestApartmentDetailDto;
+import kancho.realestate.comparingprices.domain.model.ApartmentDetail;
+
+@Component
+public class ApartmentApiClient {
+	@Value("${data-go-kr.apartment-price-detail.accessKey}")
+	private String accessKey;
+	@Value("${data-go-kr.domain-name}")
+	private String domainName;
+	@Value("${data-go-kr.apartment-price-detail.path}")
+	private String path;
+
+	private final String encoder = "UTF-8";
+	private final String pageNo = "1"; // 페이지번호
+	private final String numOfRows = "1000"; // 한 페이지 결과 수
+
+	public List<ApartmentDetail> getApartmentDetails(RequestApartmentDetailDto requestDto) throws IOException, JAXBException {
+			URL url = new URL(makeRequestUrl(requestDto));
+			String responseAsXmlString = request(url); // 공공 API에 데이터 요청
+			return new ApartmentXmlMapper().apartmentXmlToList(responseAsXmlString);
+	}
+
+	private String makeRequestUrl(RequestApartmentDetailDto requestDto) throws UnsupportedEncodingException {
+		String dealYearAndMonth = Integer.toString(requestDto.getDealYear()) + Integer.toString(requestDto.getDealMonth());
+		StringBuilder urlBuilder = new StringBuilder();
+		return urlBuilder.append(domainName).append(path)
+			.append("?").append(encode("serviceKey", encoder)).append(accessKey)
+			.append("&").append(encode("pageNo", encoder)).append("=").append(encode(pageNo, encoder))
+			.append("&").append(encode("numOfRows", encoder)).append("=").append(encode(numOfRows, encoder))
+			.append("&").append(encode("LAWD_CD", encoder)).append("=").append(encode(requestDto.getRegionalCode(), encoder))
+			.append("&").append(encode("DEAL_YMD", encoder)).append("=").append(encode(dealYearAndMonth, encoder))
+			.toString();
+	}
+
+	private String request(URL url) throws IOException {
+		HttpURLConnection httpURLConnection = getHttpURLConnection(url);
+		String response = getHttpResponse(httpURLConnection);
+		httpURLConnection.disconnect();
+		return response;
+	}
+
+	private HttpURLConnection getHttpURLConnection(URL url) throws IOException {
+		HttpURLConnection httpURLConnection = (HttpURLConnection)url.openConnection();
+		httpURLConnection.setRequestMethod("GET");
+		httpURLConnection.setRequestProperty("Content-type", "application/json");
+		return httpURLConnection;
+	}
+
+	private String getHttpResponse(HttpURLConnection httpURLConnection) throws IOException {
+		BufferedReader rd = new BufferedReader(new InputStreamReader(httpURLConnection.getInputStream()));
+		StringBuilder response = new StringBuilder();
+		String line;
+		while ((line = rd.readLine()) != null) {
+			response.append(line);
+		}
+		rd.close();
+
+		return response.toString();
+	}
+}

--- a/src/main/java/kancho/realestate/utils/api/storeaprtment/ApartmentXmlMapper.java
+++ b/src/main/java/kancho/realestate/utils/api/storeaprtment/ApartmentXmlMapper.java
@@ -1,0 +1,49 @@
+package kancho.realestate.utils.api.storeaprtment;
+
+import java.io.StringReader;
+import java.util.List;
+
+import javax.xml.bind.JAXBContext;
+import javax.xml.bind.JAXBException;
+import javax.xml.bind.Unmarshaller;
+
+import kancho.realestate.comparingprices.domain.model.ApartmentDetail;
+import kancho.realestate.comparingprices.domain.model.ApartmentDetails;
+import kancho.realestate.comparingprices.exception.InvalidApartmentXmlException;
+
+public class ApartmentXmlMapper {
+
+	public List<ApartmentDetail> apartmentXmlToList(String xmlString) throws JAXBException {
+		String targetXml = getTargetXml(xmlString);
+		ApartmentDetails apartmentDetails = (ApartmentDetails)getUnmarshaller()
+			.unmarshal(new StringReader(targetXml));
+
+		return apartmentDetails.getApartmentDetailList();
+	}
+
+	private String getTargetXml(String xmlString) {
+		String start = "<items>";
+		String end = "</items>";
+		if (!isCorrectXml(xmlString, start, end)) {
+			throw new InvalidApartmentXmlException(xmlString);
+		}
+
+		return xmlString.substring(xmlString.indexOf(start), xmlString.indexOf(end) + end.length());
+	}
+
+	private boolean isCorrectXml(String xmlString, String start, String end) {
+		if (xmlString.contains(start) && xmlString.contains(end)) {
+			return true;
+		}
+
+		return false;
+	}
+
+	private Unmarshaller getUnmarshaller() throws JAXBException {
+		return getJAXBContext().createUnmarshaller();
+	}
+
+	private JAXBContext getJAXBContext() throws JAXBException {
+		return JAXBContext.newInstance(ApartmentDetails.class);
+	}
+}

--- a/src/main/java/kancho/realestate/utils/excel/StorePricesMain.java
+++ b/src/main/java/kancho/realestate/utils/excel/StorePricesMain.java
@@ -1,4 +1,4 @@
-package kancho.realestate.utils;
+package kancho.realestate.utils.excel;
 
 import org.springframework.boot.WebApplicationType;
 import org.springframework.boot.autoconfigure.SpringBootApplication;

--- a/src/main/java/kancho/realestate/utils/excel/storeaprtment/ApartmentInfoStore.java
+++ b/src/main/java/kancho/realestate/utils/excel/storeaprtment/ApartmentInfoStore.java
@@ -1,4 +1,4 @@
-package kancho.realestate.utils.storeaprtment;
+package kancho.realestate.utils.excel.storeaprtment;
 
 import java.io.FileInputStream;
 import java.io.IOException;

--- a/src/main/java/kancho/realestate/utils/excel/storeaprtment/ApartmentStoreMapper.java
+++ b/src/main/java/kancho/realestate/utils/excel/storeaprtment/ApartmentStoreMapper.java
@@ -1,4 +1,4 @@
-package kancho.realestate.utils.storeaprtment;
+package kancho.realestate.utils.excel.storeaprtment;
 
 import java.util.List;
 import java.util.Optional;

--- a/src/main/resources/mybatis-mapper/ApartmentStoreMapper.xml
+++ b/src/main/resources/mybatis-mapper/ApartmentStoreMapper.xml
@@ -3,7 +3,7 @@
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN"
         "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
 
-<mapper namespace="kancho.realestate.utils.storeaprtment.ApartmentStoreMapper">
+<mapper namespace="kancho.realestate.utils.excel.storeaprtment.ApartmentStoreMapper">
 
     <insert id="save" parameterType="Apartment" useGeneratedKeys="true" keyProperty="id">
         insert

--- a/src/test/java/kancho/realestate/utils/api/storeaprtment/ApartmentApiClientTest.java
+++ b/src/test/java/kancho/realestate/utils/api/storeaprtment/ApartmentApiClientTest.java
@@ -1,0 +1,67 @@
+package kancho.realestate.utils.api.storeaprtment;
+
+import static org.assertj.core.api.Assertions.*;
+
+import java.io.IOException;
+import java.util.List;
+
+import javax.xml.bind.JAXBException;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+
+import kancho.realestate.comparingprices.domain.dto.request.RequestApartmentDetailDto;
+import kancho.realestate.comparingprices.domain.model.ApartmentDetail;
+import kancho.realestate.comparingprices.exception.InvalidDealYearAndMonthException;
+import kancho.realestate.comparingprices.exception.InvalidRegionalCodeException;
+
+@SpringBootTest(classes = ApartmentApiClient.class)
+class ApartmentApiClientTest {
+
+	@Autowired
+	private ApartmentApiClient apartmentApiClient;
+	private final String existingRegionalCode = "11110";
+	private final String notExistingRegionalCode = "4444444";
+	private final int correctDealYear = 2015;
+	private final int correctDealMonth = 12;
+	private final int notExistingDealMonth = 44;
+	private final int futureDealYear = 9999;
+
+	@Test
+	void 존재하는_지역코드와_올바른_계약날짜를_입력하면_아파트정보_요청_성공() throws JAXBException, IOException {
+		RequestApartmentDetailDto requestDto = new RequestApartmentDetailDto(existingRegionalCode, correctDealYear,
+			correctDealMonth);
+
+		List<ApartmentDetail> apartmentDetailList = apartmentApiClient.getApartmentDetails(requestDto);
+
+		assertThat(apartmentDetailList.get(0).toString())
+			.contains(existingRegionalCode);
+	}
+
+	@Test
+	void 존재하지_않는_지역코드를_입력하면_예외_발생() {
+		assertThatThrownBy(() -> {
+			RequestApartmentDetailDto requestDto = new RequestApartmentDetailDto(notExistingRegionalCode,
+				correctDealYear, correctDealMonth);
+		}).isInstanceOf(InvalidRegionalCodeException.class);
+	}
+
+	@Test
+	void 달력에_존재하지_않는_계약월을_입력하면_예외_발생() {
+		assertThatThrownBy(() -> {
+			RequestApartmentDetailDto requestDto = new RequestApartmentDetailDto(existingRegionalCode, correctDealYear,
+				notExistingDealMonth);
+		}).isInstanceOf(InvalidDealYearAndMonthException.class);
+	}
+
+	@Test
+	void 현재_보다_미래의_계약날짜를_입력하면_예외_발생() {
+		// 현재 연도와 동일한 연도, 미래의 월을 입력해도 동일한 오류가 발생한다.
+		assertThatThrownBy(() -> {
+			RequestApartmentDetailDto requestDto = new RequestApartmentDetailDto(existingRegionalCode, futureDealYear,
+				correctDealMonth);
+		}).isInstanceOf(InvalidDealYearAndMonthException.class);
+	}
+
+}

--- a/src/test/java/kancho/realestate/utils/api/storeaprtment/ApartmentXmlMapperTest.java
+++ b/src/test/java/kancho/realestate/utils/api/storeaprtment/ApartmentXmlMapperTest.java
@@ -1,0 +1,33 @@
+package kancho.realestate.utils.api.storeaprtment;
+
+import java.util.List;
+import javax.xml.bind.JAXBException;
+
+import org.junit.jupiter.api.Test;
+import static org.assertj.core.api.Assertions.*;
+
+import kancho.realestate.comparingprices.domain.model.ApartmentDetail;
+import kancho.realestate.comparingprices.exception.InvalidApartmentXmlException;
+
+class ApartmentXmlMapperTest {
+	private final ApartmentXmlMapper apartmentXmlMapper = new ApartmentXmlMapper();
+
+	@Test
+	void items_태그가_포함된_xml데이터를_입력하면_파싱_성공() throws JAXBException {
+		String twoApartmnetXmlString = "<items><item><아파트>땡땡아파트</아파트></item><item><아파트>모모아파트</아파트></item></items>";
+
+		List<ApartmentDetail> apartmentDetailList = apartmentXmlMapper.apartmentXmlToList(twoApartmnetXmlString);
+
+		assertThat(apartmentDetailList.size())
+			.isEqualTo(2);
+	}
+
+	@Test
+	void items_태그가_미포함된_xml데이터를_입력하면_예외_발생() throws JAXBException {
+		String incorrectXmlString = "<incorrectTag></incorrectTag>";
+
+		assertThatThrownBy(() -> {
+			List<ApartmentDetail> apartmentDetailList = apartmentXmlMapper.apartmentXmlToList(incorrectXmlString);
+		}).isInstanceOf(InvalidApartmentXmlException.class);
+	}
+}

--- a/src/test/java/kancho/realestate/utils/api/storeaprtment/model/GuTest.java
+++ b/src/test/java/kancho/realestate/utils/api/storeaprtment/model/GuTest.java
@@ -1,0 +1,27 @@
+package kancho.realestate.utils.api.storeaprtment.model;
+import static org.assertj.core.api.Assertions.*;
+
+import org.junit.jupiter.api.Test;
+
+import kancho.realestate.comparingprices.domain.model.Gu;
+
+class GuTest {
+
+	@Test
+	void 존재하는_지역번호를_찾으면_true_반환() {
+		String existingRegionalCode = "11680";
+
+		boolean isCorrect = Gu.isCorrectRegionalCode(existingRegionalCode);
+
+		assertThat(isCorrect).isTrue();
+	}
+
+	@Test
+	void 존재하지_않는_지역번호를_찾으면_false_반환() {
+		String existingRegionalCode = "4444";
+
+		boolean isCorrect = Gu.isCorrectRegionalCode(existingRegionalCode);
+
+		assertThat(isCorrect).isFalse();
+	}
+}


### PR DESCRIPTION
## 1. 공공데이터 api에 아파트 데이터 요청 후 List 객체로 반환
- 요청시 XML 형식으로 데이터를 받는다.<br>

관련 코드 <br>
- ApartmentApiClient
- RequestApartmentDetailDto
- Gu


## 2. XML 형식의 아파트 데이터를 ApartmentDetail 객체로 매핑
- JAXB 라이브러리를 사용한다. 

관련 코드 <br>
- ApartmentXmlMapper
- ApartmentDetail
- apartmentDetails